### PR TITLE
Add _right_brace special case since parser can't parse '}'

### DIFF
--- a/example.vlex
+++ b/example.vlex
@@ -1,6 +1,8 @@
 tokens {
     +
     -
+    {
+    _right_brace
     func FUNCTION
     fn FUNCTION
     _integer_literal INTS

--- a/source/parser/Parser.cpp
+++ b/source/parser/Parser.cpp
@@ -141,7 +141,14 @@ namespace parser
 
         if (text[0] == '_') // Special case
         {
-            mSpecials.push_back({ text, tokenType });
+            if (text == "_right_brace")
+            {
+                mSymbols.push_back({ "}", tokenType });
+            }
+            else
+            {
+                mSpecials.push_back({ text, tokenType });
+            }
         }
         else
         {


### PR DESCRIPTION
It literally just converts the special to a } symbol in parser 😭